### PR TITLE
fix#19 稼働と乗車画面に遷移してもユーザメニューが表示されない

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,9 +180,9 @@ def verify_password(driver, password_str):
 
 def display_user_menu(driver):
     if is_mobile_view(driver):
-        selector = 'div[data-testid="responsive-mobile-nav"] button[data-tracking-alias="loggedin drawer activated"]'
+        selector = 'div[data-testid="responsive-mobile-nav"] button[aria-label="loggedIn drawer"]'
     else:
-        selector = 'div[data-testid="responsive-desktop-nav"] button[data-tracking-alias="loggedin drawer activated"]'
+        selector = 'div[data-testid="responsive-desktop-nav"] button[aria-label="loggedIn drawer"]'
 
     # ユーザメニューを表示
     try:


### PR DESCRIPTION
ユーザメニューのボタンの検索条件をWebページ側の変更に合わせて、下記に変更する。
変更前：button[data-tracking-alias="loggedin drawer activated]"
↓
変更後：button[aria-label="loggedIn drawer"]

close #19