### PR TITLE
fix#23 トップページを開いても直後にスクリプトが終了してしまう

### DIFF
--- a/ue_scraper.py
+++ b/ue_scraper.py
@@ -81,7 +81,10 @@ class UeScraper:
         )
 
     def _click_sign_in(self):
-        self.driver.find_element(By.LINK_TEXT, 'サインイン').click()
+        sign_in = WebDriverWait(self.driver, self.TIMEOUTS_SEC['wait']).until(
+                EC.element_to_be_clickable((By.LINK_TEXT, 'サインイン'))
+        )
+        sign_in.click()
         WebDriverWait(self.driver, self.TIMEOUTS_SEC['wait']).until(
             EC.presence_of_all_elements_located((By.TAG_NAME, 'body'))
         )


### PR DESCRIPTION
サインインボタンがクリックできるようになるまで待つように対策

close #23